### PR TITLE
Rename configuration class: GoogleSuggest::Configuration

### DIFF
--- a/lib/google_suggest.rb
+++ b/lib/google_suggest.rb
@@ -9,20 +9,18 @@ class GoogleSuggest
   attr_accessor :home_language
   attr_accessor :proxy
 
-  class << self
-    def configure
-      yield configuration if block_given?
+  def self.configure
+    yield configuration if block_given?
 
-      configuration
-    end
+    configuration
+  end
 
-    def configuration
-      @configuration ||= Configuration.new
-    end
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
 
-    def suggest_for(keyword)
-      self.new.suggest_for(keyword)
-    end
+  def self.suggest_for(keyword)
+    self.new.suggest_for(keyword)
   end
 
   def initialize

--- a/lib/google_suggest.rb
+++ b/lib/google_suggest.rb
@@ -3,21 +3,13 @@
 require 'uri'
 require 'nokogiri'
 require 'net/http'
+require 'google_suggest/configuration'
 
 class GoogleSuggest
-  class Configure
-    attr_accessor :home_language
-    attr_accessor :proxy
-
-    def initialize
-      @home_language = 'en'
-    end
-  end
+  @@configure = Configuration.new
 
   attr_accessor :home_language
   attr_accessor :proxy
-
-  @@configure = Configure.new
 
   class << self
     def configure

--- a/lib/google_suggest.rb
+++ b/lib/google_suggest.rb
@@ -6,15 +6,18 @@ require 'net/http'
 require 'google_suggest/configuration'
 
 class GoogleSuggest
-  @@configure = Configuration.new
-
   attr_accessor :home_language
   attr_accessor :proxy
 
   class << self
     def configure
-      yield @@configure if block_given?
-      @@configure
+      yield configuration if block_given?
+
+      configuration
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
     end
 
     def suggest_for(keyword)
@@ -23,8 +26,8 @@ class GoogleSuggest
   end
 
   def initialize
-    @home_language = @@configure.home_language
-    @proxy = @@configure.proxy
+    @home_language = self.class.configuration.home_language
+    @proxy = self.class.configuration.proxy
   end
 
   def suggest_for(keyword)

--- a/lib/google_suggest/configuration.rb
+++ b/lib/google_suggest/configuration.rb
@@ -1,0 +1,10 @@
+class GoogleSuggest
+  class Configuration
+    attr_accessor :home_language
+    attr_accessor :proxy
+
+    def initialize
+      @home_language = 'en'
+    end
+  end
+end

--- a/spec/google_suggest_spec.rb
+++ b/spec/google_suggest_spec.rb
@@ -36,7 +36,7 @@ describe GoogleSuggest do
     end
   end
 
-  describe GoogleSuggest::Configure do
+  describe GoogleSuggest::Configuration do
     context "#configure called without block" do
       before do
         @configure = GoogleSuggest.configure


### PR DESCRIPTION
OMG, `GoogleSuggest::Configure` allows users to configure the behavior of `GoogleSuggest` objects. 
But its name looks baaaaaad ;( 
