### PR TITLE
Enable caching bundled gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
+language: ruby
+
 rvm:
   - 2.1.9
   - 2.2.5
   - 2.3.1
   - ruby-head
+
+cache: bundler
 
 before_install:
   - gem install bundler


### PR DESCRIPTION
The past builds take much time in installing gem with bundler.  
https://travis-ci.org/satoryu/google_suggest/builds/132346745

This would be resolved by using [caching bundled gems](https://docs.travis-ci.com/user/caching#Bundler), I think.
