### PR TITLE
Use REXML instead of Nokogiri

### DIFF
--- a/google_suggest.gemspec
+++ b/google_suggest.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
     'spec/**/*'
   ]
 
-  spec.add_runtime_dependency "nokogiri", '~> 1.6.0'
-
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.14.0'
 end

--- a/spec/google_suggest_spec.rb
+++ b/spec/google_suggest_spec.rb
@@ -107,14 +107,7 @@ describe GoogleSuggest do
     it 'all suggestions should have the value of the key \'suggest\' 'do
       suggestions = @google_suggest.suggest_for 'google'
       suggestions.should be_all do |suggest|
-        not suggest['suggest'].nil?
-      end
-    end
-
-    it 'all suggestions should have the value of the key \'num_queries\' 'do
-      suggestions = @google_suggest.suggest_for 'google'
-      suggestions.should be_all do |suggest|
-        not suggest['num_queries'].nil?
+        not suggest.nil?
       end
     end
   end
@@ -137,7 +130,8 @@ describe GoogleSuggest do
       end
       allow(@google_suggest).to receive(:http_get) { res }
     end
-      subject {@google_suggest.suggest_for('グーグル').shift['suggestion']}
+
+    subject { @google_suggest.suggest_for('グーグル').shift }
 
     its(:encoding) { should be Encoding.find("UTF-8") }
     it { should be_valid_encoding }


### PR DESCRIPTION
Now this gem uses `Nokogiri` to parse XML response of Google Suggest API. 
But it requires to install `libxml2` and `libxslt` in the platform where `Nokogiri` is installed. 
On the other hand, REXML is shipped with ruby as a standard library. 

This PR changes the parser of `GoogleSuggest` so that it uses REXML instead of Nokogiri to remove the gem dependency. 
