### PR TITLE
Fix `NameError: uninitialized constant GoogleSuggest::Region::DEFAULT_GOOGLE_HOST`

### DIFF
--- a/lib/google_suggest/region.rb
+++ b/lib/google_suggest/region.rb
@@ -200,9 +200,8 @@ class GoogleSuggest
 
   class Region
     def self.host_for(region_code=nil)
-      region_code = :com if region_code.nil?
       region_code = region_code.to_sym if region_code.is_a?(String)
-      GOOGLE_HOSTS[region_code] || DEFAULT_GOOGLE_HOST
+      GOOGLE_HOSTS[region_code] || GOOGLE_HOSTS[:com]
     end
   end
 end

--- a/spec/google_suggest/region_spec.rb
+++ b/spec/google_suggest/region_spec.rb
@@ -18,5 +18,12 @@ describe GoogleSuggest::Region do
         should be_eql('www.google.ac')
       end
     end
+    context 'when giving an undefined region code like "zz"' do
+      let(:region_code) { 'zz' }
+
+      it 'should be the default host' do
+        should be_eql('www.google.com')
+      end
+    end
   end
 end


### PR DESCRIPTION
When giving an undefined region code like `'zz'` to `GoogleSuggest.suggest_for` or `GoogleSuggest#suggest_for`, the `NameError: uninitialized constant GoogleSuggest::Region::DEFAULT_GOOGLE_HOST` is raised. 
